### PR TITLE
fix(map): <plug>(NERDTermToggle) didn't work in the terminal

### DIFF
--- a/plugin/nerdterm.vim
+++ b/plugin/nerdterm.vim
@@ -10,4 +10,5 @@
 command NERDTermToggle call nerdterm#Toggle()
 
 map <Plug>(NERDTermToggle) <Cmd>NERDTermToggle<CR>
+tmap <Plug>(NERDTermToggle) <Cmd>NERDTermToggle<CR>
 


### PR DESCRIPTION
Maps have to be explicitly defined for the terminal, so when the mappings got optimized the plug mapping stopped working when the cursor was in the terminal.